### PR TITLE
Removed emitOn on default worker pool for watsonx.ai

### DIFF
--- a/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/AiChatServiceTest.java
+++ b/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/AiChatServiceTest.java
@@ -45,6 +45,7 @@ import io.quarkiverse.langchain4j.watsonx.bean.TextChatRequest;
 import io.quarkiverse.langchain4j.watsonx.runtime.config.ChatModelConfig;
 import io.quarkiverse.langchain4j.watsonx.runtime.config.LangChain4jWatsonxConfig;
 import io.quarkus.test.QuarkusUnitTest;
+import io.smallrye.common.annotation.Blocking;
 import io.smallrye.mutiny.Multi;
 
 public class AiChatServiceTest extends WireMockAbstract {
@@ -106,6 +107,7 @@ public class AiChatServiceTest extends WireMockAbstract {
     @Singleton
     static class Calculator {
         @Tool("Execute the sum of two numbers")
+        @Blocking
         public int sum(int first, int second) {
             return first + second;
         }

--- a/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/WatsonxChatModel.java
+++ b/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/WatsonxChatModel.java
@@ -32,7 +32,6 @@ import io.quarkiverse.langchain4j.watsonx.bean.TextChatResponse.TextChatUsage;
 import io.quarkiverse.langchain4j.watsonx.bean.TextStreamingChatResponse;
 import io.quarkiverse.langchain4j.watsonx.bean.TokenizationRequest;
 import io.smallrye.mutiny.Context;
-import io.smallrye.mutiny.infrastructure.Infrastructure;
 
 public class WatsonxChatModel extends Watsonx implements ChatLanguageModel, StreamingChatLanguageModel, TokenCountEstimator {
 
@@ -110,14 +109,8 @@ public class WatsonxChatModel extends Watsonx implements ChatLanguageModel, Stre
         context.put(TOOLS_CONTEXT, new ArrayList<StreamingToolFetcher>());
         context.put(COMPLETE_MESSAGE_CONTEXT, new StringBuilder());
 
-        var mutiny = client.streamingChat(request, version);
-        if (tools != null) {
-            // Today Langchain4j doesn't allow to use the async operation with tools.
-            // One idea might be to give to the developer the possibility to use the VirtualThread.
-            mutiny.emitOn(Infrastructure.getDefaultWorkerPool());
-        }
-
-        mutiny.subscribe()
+        client.streamingChat(request, version)
+                .subscribe()
                 .with(context,
                         new Consumer<TextStreamingChatResponse>() {
                             @Override


### PR DESCRIPTION
To run the new test, go to the watsonx folder and run the command:
```cmd
mvn clean install -Dtest=AiChatServiceTest#streaming_chat_with_tool -Dmaven.surefire.debug -Dsurefire.failIfNoSpecifiedTests=false
```